### PR TITLE
set mcp tool invoke timeout to simulation tool timeout 

### DIFF
--- a/src/extension/tools/vscode-node/mcpToolsService.ts
+++ b/src/extension/tools/vscode-node/mcpToolsService.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 /* eslint-disable import/no-restricted-paths */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol';
 import { CancellationError, LanguageModelTextPart, LanguageModelToolInformation, LanguageModelToolResult } from 'vscode';
 import { ILogService } from '../../../platform/log/common/logService';
 import { Lazy } from '../../../util/vs/base/common/lazy';
@@ -106,7 +105,7 @@ export class McpToolsService extends BaseToolsService {
 
 	async invokeTool(name: string | ToolName, options: vscode.LanguageModelToolInvocationOptions<Object>, token: vscode.CancellationToken): Promise<LanguageModelToolResult | vscode.LanguageModelToolResult2> {
 		this._onWillInvokeTool.fire({ toolName: name });
-		const invokeToolTimeout = process.env.SIMULATION_INVOKE_TOOL_TIMEOUT ? parseInt(process.env.SIMULATION_INVOKE_TOOL_TIMEOUT) : DEFAULT_REQUEST_TIMEOUT_MSEC;
+		const invokeToolTimeout = process.env.SIMULATION_INVOKE_TOOL_TIMEOUT ? parseInt(process.env.SIMULATION_INVOKE_TOOL_TIMEOUT) : 60_000;
 		const result = await this.mcp?.callTool({
 			name: name,
 			arguments: options.input as Record<string, unknown>,

--- a/src/extension/tools/vscode-node/mcpToolsService.ts
+++ b/src/extension/tools/vscode-node/mcpToolsService.ts
@@ -105,11 +105,11 @@ export class McpToolsService extends BaseToolsService {
 
 	async invokeTool(name: string | ToolName, options: vscode.LanguageModelToolInvocationOptions<Object>, token: vscode.CancellationToken): Promise<LanguageModelToolResult | vscode.LanguageModelToolResult2> {
 		this._onWillInvokeTool.fire({ toolName: name });
-		const invokeToolTimeout = process.env.SIMULATION_INVOKE_TOOL_TIMEOUT ? parseInt(process.env.SIMULATION_INVOKE_TOOL_TIMEOUT) : 60_000;
+		const invokeToolTimeout = process.env.SIMULATION_INVOKE_TOOL_TIMEOUT ? parseInt(process.env.SIMULATION_INVOKE_TOOL_TIMEOUT, 10) : 60_000;
 		const result = await this.mcp?.callTool({
 			name: name,
 			arguments: options.input as Record<string, unknown>,
-		}, undefined, { timeout: invokeToolTimeout });
+		}, undefined, { timeout: invokeToolTimeout, maxTotalTimeout: invokeToolTimeout });
 		if (!result) {
 			throw new CancellationError();
 		}


### PR DESCRIPTION
This pull request updates the `McpToolsService` implementation in `src/extension/tools/vscode-node/mcpToolsService.ts` to improve import handling and add configurable timeouts for tool invocation. The most significant changes are grouped below.

**Import and dependency management:**

* Reordered and cleaned up imports by moving the `vscode` import after `fs`, removing duplicate and unnecessary import statements, and updating linting comments for clarity. [[1]](diffhunk://#diff-bf28477c753b3dad81918488e4173a0aece74b9ca0d0239678220559c7298664L5-R6) [[2]](diffhunk://#diff-bf28477c753b3dad81918488e4173a0aece74b9ca0d0239678220559c7298664L18-R17)

**Tool invocation improvements:**

* Updated the `invokeTool` method to support a configurable timeout via the `SIMULATION_INVOKE_TOOL_TIMEOUT` environment variable, ensuring tool calls do not hang indefinitely and are easier to test in simulation environments.