### PR TITLE
Support multiple mcp server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
 				"open": "^10.1.2",
 				"outdent": "^0.8.0",
 				"picomatch": "^4.0.2",
-				"playwright": "^1.54.0",
+				"playwright": "^1.54.2",
 				"prettier": "^3.6.2",
 				"react": "^17.0.2",
 				"react-dom": "17.0.2",
@@ -118,7 +118,7 @@
 			"engines": {
 				"node": ">=22.14.0",
 				"npm": ">=9.0.0",
-				"vscode": "^1.103.0-20250721"
+				"vscode": "^1.103.0-20250725"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -14338,13 +14338,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.0.tgz",
-			"integrity": "sha512-y9yzHmXRwEUOpghM7XGcA38GjWuTOUMaTIcm/5rHcYVjh5MSp9qQMRRMc/+p1cx+csoPnX4wkxAF61v5VKirxg==",
+			"version": "1.54.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+			"integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.54.0"
+				"playwright-core": "1.54.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -14382,6 +14382,19 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/playwright/node_modules/playwright-core": {
+			"version": "1.54.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+			"integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -3622,7 +3622,7 @@
 		"open": "^10.1.2",
 		"outdent": "^0.8.0",
 		"picomatch": "^4.0.2",
-		"playwright": "^1.54.0",
+		"playwright": "^1.54.2",
 		"prettier": "^3.6.2",
 		"react": "^17.0.2",
 		"react-dom": "17.0.2",

--- a/src/extension/tools/vscode-node/mcpToolsService.ts
+++ b/src/extension/tools/vscode-node/mcpToolsService.ts
@@ -207,23 +207,20 @@ export class McpToolsService extends BaseToolsService {
 			throw new Error(`MCP client for server ${serverName} not found`);
 		}
 
-		try {
-			const invokeToolTimeout = process.env.SIMULATION_INVOKE_TOOL_TIMEOUT ? parseInt(process.env.SIMULATION_INVOKE_TOOL_TIMEOUT, 10) : 60_000;
-			const result = await mcpClient.callTool({
-				name: name,
-				arguments: options.input as Record<string, unknown>,
-			}, undefined, { timeout: invokeToolTimeout, maxTotalTimeout: invokeToolTimeout });
-			if (!result) {
-				throw new CancellationError();
-			}
-			const parts = [];
-			for (const part of result.content as { text: string }[]) {
-				parts.push(new LanguageModelTextPart(part.text as string));
-			}
-			return new LanguageModelToolResult(parts);
-		} catch (error) {
-			throw error;
+
+		const invokeToolTimeout = process.env.SIMULATION_INVOKE_TOOL_TIMEOUT ? parseInt(process.env.SIMULATION_INVOKE_TOOL_TIMEOUT, 10) : 60_000;
+		const result = await mcpClient.callTool({
+			name: name,
+			arguments: options.input as Record<string, unknown>,
+		}, undefined, { timeout: invokeToolTimeout, maxTotalTimeout: invokeToolTimeout });
+		if (!result) {
+			throw new CancellationError();
 		}
+		const parts = [];
+		for (const part of result.content as { text: string }[]) {
+			parts.push(new LanguageModelTextPart(part.text as string));
+		}
+		return new LanguageModelToolResult(parts);
 	}
 
 	override getCopilotTool(name: string): ICopilotTool<any> | undefined {

--- a/src/extension/tools/vscode-node/mcpToolsService.ts
+++ b/src/extension/tools/vscode-node/mcpToolsService.ts
@@ -2,11 +2,10 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as fs from 'fs';
-import * as vscode from 'vscode';
-/* eslint-disable import/no-restricted-paths */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import * as fs from 'fs';
+import * as vscode from 'vscode';
 import { CancellationError, LanguageModelTextPart, LanguageModelToolInformation, LanguageModelToolResult } from 'vscode';
 import { ILogService } from '../../../platform/log/common/logService';
 import { Lazy } from '../../../util/vs/base/common/lazy';
@@ -16,7 +15,6 @@ import { ICopilotTool } from '../common/toolsRegistry';
 import { BaseToolsService } from '../common/toolsService';
 // eslint-disable-next-line no-duplicate-imports
 import { LanguageModelToolResult2 } from 'vscode';
-import { logger } from '../../../../test/simulationLogger';
 
 type McpServers = {
 	servers: {
@@ -37,8 +35,20 @@ export class McpToolsService extends BaseToolsService {
 	private mcpTools: vscode.LanguageModelToolInformation[] = [];
 	private readonly mcpClients: Map<string, Client> = new Map();
 	private readonly toolToServerMap: Map<string, string> = new Map();
+	private initializationPromise: Promise<void> | undefined;
+
+	/**
+	 * Check if all MCP servers have been initialized
+	 * @returns true if all MCP servers have completed initialization, false otherwise
+	 */
+	static isMcpServersInitialized(): boolean {
+		return process.env.MCP_SERVERS_INITIALIZED === 'true';
+	}
 
 	get tools(): ReadonlyArray<vscode.LanguageModelToolInformation> {
+		// Trigger initialization if not already done
+		this.ensureInitialized();
+
 		return this.mcpTools.map(tool => {
 			return {
 				...tool,
@@ -59,63 +69,133 @@ export class McpToolsService extends BaseToolsService {
 	) {
 		super(logService);
 		this._copilotTools = new Lazy(() => new Map());
-		if (process.env.MCP_CONFIG_FILE !== undefined) {
+
+		// Initialize the environment variable as false at startup
+		process.env.MCP_SERVERS_INITIALIZED = 'false';
+	}
+
+	/**
+	 * Ensures the MCP tools are initialized. This method is called lazily when tools are accessed.
+	 */
+	private ensureInitialized(): void {
+		if (this.initializationPromise) {
+			return; // Already initializing or initialized
+		}
+
+		this.initializationPromise = this.initializeAsync();
+	}
+
+	/**
+	 * Ensures the MCP tools are initialized and waits for completion. Used in async contexts.
+	 */
+	private async ensureInitializedAsync(): Promise<void> {
+		if (!this.initializationPromise) {
+			this.initializationPromise = this.initializeAsync();
+		}
+		await this.initializationPromise;
+	}
+
+	/**
+	 * Asynchronously initialize MCP clients and tools
+	 */
+	private async initializeAsync(): Promise<void> {
+		if (process.env.MCP_CONFIG_FILE === undefined) {
+			return;
+		}
+
+		try {
 			const config = fs.readFileSync(process.env.MCP_CONFIG_FILE, 'utf8');
 			const mcpServers: McpServers = JSON.parse(config);
 
+			const initPromises: Promise<void>[] = [];
+
 			for (const [name, server] of Object.entries(mcpServers.servers)) {
-				let transport;
-				const configuredEnv = server.env ? Object.fromEntries(Object.entries(server.env).map(([key, value]) => [key, replaceEnvVariables(value)])) : undefined;
-				// combine env with process.env, ensuring all values are strings (no undefined)
-				const rawEnv = configuredEnv ? { ...process.env, ...configuredEnv } : process.env;
-				const combinedEnv: Record<string, string> = {};
-				for (const [key, value] of Object.entries(rawEnv)) {
-					if (typeof value === 'string') {
-						combinedEnv[key] = value;
-					}
-				}
+				initPromises.push(this.initializeServer(name, server));
+			}
 
-				if (server.type === 'stdio') {
-					transport = new StdioClientTransport({
-						command: replaceEnvVariables(server.command),
-						args: server.args.map(arg => replaceEnvVariables(arg)),
-						env: combinedEnv,
-						stderr: 'inherit', // Default behavior, can be customized if needed
-						cwd: server.cwd ? replaceEnvVariables(server.cwd) : undefined,
-					});
-				} else {
-					logger.warn(`Unsupported MCP transport type: ${server.type} for server ${name}`);
-					continue; // Unsupported transport type
-				}
+			await Promise.allSettled(initPromises);
 
+			// Set environment variable to indicate all MCP servers have completed initialization
+			process.env.MCP_SERVERS_INITIALIZED = 'true';
+		} catch (error) {
+		}
+	}
+
+	/**
+	 * Initialize a single MCP server
+	 */
+	private async initializeServer(name: string, server: {
+		type: string;
+		command: string;
+		args: string[];
+		env?: Record<string, string>;
+		cwd?: string;
+	}): Promise<void> {
+		let transport;
+		const configuredEnv = server.env ? Object.fromEntries(Object.entries(server.env).map(([key, value]) => [key, replaceEnvVariables(value)])) : undefined;
+		// combine env with process.env, ensuring all values are strings (no undefined)
+		const rawEnv = configuredEnv ? { ...process.env, ...configuredEnv } : process.env;
+		const combinedEnv: Record<string, string> = {};
+		for (const [key, value] of Object.entries(rawEnv)) {
+			if (typeof value === 'string') {
+				combinedEnv[key] = value;
+			}
+		}
+
+		if (server.type === 'stdio') {
+			transport = new StdioClientTransport({
+				command: replaceEnvVariables(server.command),
+				args: server.args.map((arg: string) => replaceEnvVariables(arg)),
+				env: combinedEnv,
+				stderr: 'inherit', // Default behavior, can be customized if needed
+				cwd: server.cwd ? replaceEnvVariables(server.cwd) : undefined,
+			});
+		} else {
+			return; // Unsupported transport type
+		}
+
+		const maxRetries = 5;
+		const retryDelay = 2000; // 2 seconds
+
+		for (let attempt = 1; attempt <= maxRetries; attempt++) {
+			try {
 				// Create a separate client for each server
 				const mcpClient = new Client({ name: `mcp-client-${name}`, version: '1.0.0' });
 				this.mcpClients.set(name, mcpClient);
 
-				mcpClient.connect(transport).then(async () => {
-					const mcpTools = (await mcpClient.listTools()).tools;
-					for (const tool of mcpTools) {
-						const info: LanguageModelToolInformation = {
-							name: tool.name,
-							description: tool.description as string,
-							inputSchema: tool.inputSchema,
-							tags: ['vscode_editing'],
-							source: { name: 'mcp', label: `MCP Server: ${name}` },
-						};
-						this.mcpTools.push(info);
-						// Map tool name to server name for later lookup
-						this.toolToServerMap.set(tool.name, name);
-					}
-					logger.info(`Connected to MCP server ${name} with transport ${JSON.stringify(transport)} and tools: ${JSON.stringify(mcpTools)}`);
-				}).catch(error => {
-					logger.error(`Failed to connect to MCP server ${name}: ${error}`);
-				});
+				await mcpClient.connect(transport);
+				const mcpTools = (await mcpClient.listTools()).tools;
+				for (const tool of mcpTools) {
+					const info: LanguageModelToolInformation = {
+						name: tool.name,
+						description: tool.description as string,
+						inputSchema: tool.inputSchema,
+						tags: ['vscode_editing'],
+						source: { name: 'mcp', label: `MCP Server: ${name}` },
+					};
+					this.mcpTools.push(info);
+					// Map tool name to server name for later lookup
+					this.toolToServerMap.set(tool.name, name);
+				}
+				return; // Success, exit retry loop
+			} catch (error) {
+				// Clean up failed client
+				this.mcpClients.delete(name);
+
+				if (attempt === maxRetries) {
+					return;
+				}
+
+				await new Promise(resolve => setTimeout(resolve, retryDelay));
 			}
 		}
 	}
 
 	async invokeTool(name: string | ToolName, options: vscode.LanguageModelToolInvocationOptions<Object>, token: vscode.CancellationToken): Promise<LanguageModelToolResult | LanguageModelToolResult2> {
 		this._onWillInvokeTool.fire({ toolName: name });
+
+		// Ensure initialization is complete before invoking tools
+		await this.ensureInitializedAsync();
 
 		// Find which server provides this tool
 		const serverName = this.toolToServerMap.get(name as string);
@@ -128,18 +208,24 @@ export class McpToolsService extends BaseToolsService {
 			throw new Error(`MCP client for server ${serverName} not found`);
 		}
 
-		const result = await mcpClient.callTool({
-			name: name,
-			arguments: options.input as Record<string, unknown>,
-		});
-		if (!result) {
-			throw new CancellationError();
+		const start = Date.now();
+		try {
+			const invokeToolTimeout = process.env.SIMULATION_INVOKE_TOOL_TIMEOUT ? parseInt(process.env.SIMULATION_INVOKE_TOOL_TIMEOUT, 10) : 60_000;
+			const result = await mcpClient.callTool({
+				name: name,
+				arguments: options.input as Record<string, unknown>,
+			}, undefined, { timeout: invokeToolTimeout, maxTotalTimeout: invokeToolTimeout });
+			if (!result) {
+				throw new CancellationError();
+			}
+			const parts = [];
+			for (const part of result.content as { text: string }[]) {
+				parts.push(new LanguageModelTextPart(part.text as string));
+			}
+			return new LanguageModelToolResult(parts);
+		} catch (error) {
+			throw error;
 		}
-		const parts = [];
-		for (const part of result.content as { text: string }[]) {
-			parts.push(new LanguageModelTextPart(part.text as string));
-		}
-		return new LanguageModelToolResult(parts);
 	}
 
 	override getCopilotTool(name: string): ICopilotTool<any> | undefined {
@@ -148,6 +234,8 @@ export class McpToolsService extends BaseToolsService {
 	}
 
 	getTool(name: string | ToolName): vscode.LanguageModelToolInformation | undefined {
+		// Trigger initialization if not already done
+		this.ensureInitialized();
 		return this.tools.find(tool => tool.name === name);
 	}
 
@@ -201,16 +289,17 @@ export class McpToolsService extends BaseToolsService {
 	override dispose(): void {
 		super.dispose();
 
-		for (const [serverName, client] of this.mcpClients) {
+		for (const [, client] of this.mcpClients) {
 			try {
 				client.close();
-				logger.info(`Closed MCP client connection for server: ${serverName}`);
 			} catch (error) {
-				logger.error(`Error closing MCP client for server ${serverName}: ${error}`);
 			}
 		}
 		this.mcpClients.clear();
 		this.toolToServerMap.clear();
+
+		// Reset environment variable when disposing
+		process.env.MCP_SERVERS_INITIALIZED = 'false';
 	}
 }
 

--- a/src/extension/tools/vscode-node/mcpToolsService.ts
+++ b/src/extension/tools/vscode-node/mcpToolsService.ts
@@ -2,9 +2,8 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as vscode from 'vscode';
-// eslint-disable-next-line no-restricted-imports
 import * as fs from 'fs';
+import * as vscode from 'vscode';
 /* eslint-disable import/no-restricted-paths */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -17,7 +16,6 @@ import { ICopilotTool } from '../common/toolsRegistry';
 import { BaseToolsService } from '../common/toolsService';
 // eslint-disable-next-line no-duplicate-imports
 import { LanguageModelToolResult2 } from 'vscode';
-// eslint-disable-next-line local/no-test-imports
 import { logger } from '../../../../test/simulationLogger';
 
 type McpServers = {
@@ -37,7 +35,8 @@ export class McpToolsService extends BaseToolsService {
 
 	private readonly _copilotTools: Lazy<Map<ToolName, ICopilotTool<any>>>;
 	private mcpTools: vscode.LanguageModelToolInformation[] = [];
-	private readonly mcp!: Client;
+	private readonly mcpClients: Map<string, Client> = new Map();
+	private readonly toolToServerMap: Map<string, string> = new Map();
 
 	get tools(): ReadonlyArray<vscode.LanguageModelToolInformation> {
 		return this.mcpTools.map(tool => {
@@ -61,7 +60,6 @@ export class McpToolsService extends BaseToolsService {
 		super(logService);
 		this._copilotTools = new Lazy(() => new Map());
 		if (process.env.MCP_CONFIG_FILE !== undefined) {
-			this.mcp = new Client({ name: 'mcp-simulation-client', version: '1.0.0' });
 			const config = fs.readFileSync(process.env.MCP_CONFIG_FILE, 'utf8');
 			const mcpServers: McpServers = JSON.parse(config);
 
@@ -89,18 +87,28 @@ export class McpToolsService extends BaseToolsService {
 					logger.warn(`Unsupported MCP transport type: ${server.type} for server ${name}`);
 					continue; // Unsupported transport type
 				}
-				this.mcp.connect(transport).then(async () => {
-					const mcpTools = (await this.mcp.listTools()).tools;
+
+				// Create a separate client for each server
+				const mcpClient = new Client({ name: `mcp-client-${name}`, version: '1.0.0' });
+				this.mcpClients.set(name, mcpClient);
+
+				mcpClient.connect(transport).then(async () => {
+					const mcpTools = (await mcpClient.listTools()).tools;
 					for (const tool of mcpTools) {
 						const info: LanguageModelToolInformation = {
 							name: tool.name,
 							description: tool.description as string,
 							inputSchema: tool.inputSchema,
 							tags: ['vscode_editing'],
+							source: { name: 'mcp', label: `MCP Server: ${name}` },
 						};
 						this.mcpTools.push(info);
+						// Map tool name to server name for later lookup
+						this.toolToServerMap.set(tool.name, name);
 					}
-					logger.info(`Connected to MCP server with transport ${JSON.stringify(transport)} and tools: ${JSON.stringify(this.mcpTools)}`);
+					logger.info(`Connected to MCP server ${name} with transport ${JSON.stringify(transport)} and tools: ${JSON.stringify(mcpTools)}`);
+				}).catch(error => {
+					logger.error(`Failed to connect to MCP server ${name}: ${error}`);
 				});
 			}
 		}
@@ -108,7 +116,19 @@ export class McpToolsService extends BaseToolsService {
 
 	async invokeTool(name: string | ToolName, options: vscode.LanguageModelToolInvocationOptions<Object>, token: vscode.CancellationToken): Promise<LanguageModelToolResult | LanguageModelToolResult2> {
 		this._onWillInvokeTool.fire({ toolName: name });
-		const result = await this.mcp?.callTool({
+
+		// Find which server provides this tool
+		const serverName = this.toolToServerMap.get(name as string);
+		if (!serverName) {
+			throw new Error(`Tool ${name} not found in any MCP server`);
+		}
+
+		const mcpClient = this.mcpClients.get(serverName);
+		if (!mcpClient) {
+			throw new Error(`MCP client for server ${serverName} not found`);
+		}
+
+		const result = await mcpClient.callTool({
 			name: name,
 			arguments: options.input as Record<string, unknown>,
 		});
@@ -173,6 +193,24 @@ export class McpToolsService extends BaseToolsService {
 
 			return false;
 		});
+	}
+
+	/**
+	 * Dispose of all MCP client connections
+	 */
+	override dispose(): void {
+		super.dispose();
+
+		for (const [serverName, client] of this.mcpClients) {
+			try {
+				client.close();
+				logger.info(`Closed MCP client connection for server: ${serverName}`);
+			} catch (error) {
+				logger.error(`Error closing MCP client for server ${serverName}: ${error}`);
+			}
+		}
+		this.mcpClients.clear();
+		this.toolToServerMap.clear();
 	}
 }
 

--- a/test/base/extHostContext/simulationExtHostToolsService.ts
+++ b/test/base/extHostContext/simulationExtHostToolsService.ts
@@ -9,17 +9,17 @@ import type { CancellationToken, ChatRequest, LanguageModelTool, LanguageModelTo
 import { getToolName, ToolName } from '../../../src/extension/tools/common/toolNames';
 import { ICopilotTool } from '../../../src/extension/tools/common/toolsRegistry';
 import { BaseToolsService, IToolsService } from '../../../src/extension/tools/common/toolsService';
+import { getPackagejsonToolsForTest } from '../../../src/extension/tools/node/test/testToolsService';
 import { McpToolsService } from '../../../src/extension/tools/vscode-node/mcpToolsService';
 import { ToolsContribution } from '../../../src/extension/tools/vscode-node/tools';
 import { ToolsService } from '../../../src/extension/tools/vscode-node/toolsService';
 import { packageJson } from '../../../src/platform/env/common/packagejson';
 import { ILogService } from '../../../src/platform/log/common/logService';
+import { raceTimeout } from '../../../src/util/vs/base/common/async';
 import { CancellationError } from '../../../src/util/vs/base/common/errors';
 import { Iterable } from '../../../src/util/vs/base/common/iterator';
 import { IInstantiationService } from '../../../src/util/vs/platform/instantiation/common/instantiation';
 import { logger } from '../../simulationLogger';
-import { raceTimeout } from '../../../src/util/vs/base/common/async';
-import { getPackagejsonToolsForTest } from '../../../src/extension/tools/node/test/testToolsService';
 
 export class SimulationExtHostToolsService extends BaseToolsService implements IToolsService {
 	declare readonly _serviceBrand: undefined;
@@ -140,13 +140,39 @@ export class SimulationExtHostToolsService extends BaseToolsService implements I
 	getEnabledTools(request: ChatRequest, filter?: (tool: LanguageModelToolInformation) => boolean | undefined): LanguageModelToolInformation[] {
 		const packageJsonTools = getPackagejsonToolsForTest();
 		const tools = this.tools.filter(tool => filter?.(tool) ?? (!this._disabledTools.has(getToolName(tool.name)) && (tool.name.startsWith("appmod") || packageJsonTools.has(tool.name))));
-		const result = [
-			...tools,
-		];
 
-		const toolNames = result.map(t => t.name).join(",");
-		logger.debug('SimulationExtHostToolsService.getEnabledTool', tools.length, toolNames);
-		return result;
+		this._mcpToolService.getEnabledTools(request, filter);
+
+		// Wait for MCP servers to be initialized
+		const maxWaitTime = 30000; // 30 seconds maximum wait time
+		const checkInterval = 1000; // Check every 1000ms
+		const startTime = Date.now();
+
+		while (process.env.MCP_SERVERS_INITIALIZED !== 'true' && (Date.now() - startTime) < maxWaitTime) {
+			// Use a synchronous sleep method that doesn't require external dependencies
+			const sleepStart = Date.now();
+			while (Date.now() - sleepStart < checkInterval) {
+				logger.warn('SimulationExtHostToolsService: MCP servers still initializing...');
+			}
+		}
+
+		if (process.env.MCP_SERVERS_INITIALIZED !== 'true') {
+			logger.warn('SimulationExtHostToolsService: MCP servers initialization timed out');
+		}
+
+		const mcpTools = this._mcpToolService.getEnabledTools(request, filter);
+		const allToolsMap = new Map<string, LanguageModelToolInformation>();
+		for (const t of tools) {
+			allToolsMap.set(t.name, t);
+		}
+		for (const t of mcpTools) {
+			logger.debug(`Get mcpTool: ${t.name}`);
+			allToolsMap.set(t.name, t);
+		}
+		const allTools = Array.from(allToolsMap.values());
+		const toolNames = allTools.map(t => t.name).join(",");
+		logger.debug('SimulationExtHostToolsService.getEnabledTool', allTools.length, toolNames);
+		return allTools;
 	}
 
 	addTestToolOverride(info: LanguageModelToolInformation, tool: LanguageModelTool<unknown>): void {

--- a/test/base/extHostContext/simulationExtHostToolsService.ts
+++ b/test/base/extHostContext/simulationExtHostToolsService.ts
@@ -144,14 +144,13 @@ export class SimulationExtHostToolsService extends BaseToolsService implements I
 		this._mcpToolService.getEnabledTools(request, filter);
 
 		// Wait for MCP servers to be initialized
-		const maxWaitTime = 30000; // 30 seconds maximum wait time
+		const maxWaitTime = 60000; // 60 seconds maximum wait time
 		const checkInterval = 1000; // Check every 1000ms
 		const startTime = Date.now();
 
 		while (process.env.MCP_SERVERS_INITIALIZED !== 'true' && (Date.now() - startTime) < maxWaitTime) {
 			// Use a synchronous sleep method that doesn't require external dependencies
 			const sleepStart = Date.now();
-			logger.warn('SimulationExtHostToolsService: MCP servers still initializing...');
 			while (Date.now() - sleepStart < checkInterval) {
 			}
 		}


### PR DESCRIPTION
This pull request introduces significant improvements to the MCP tools infrastructure, focusing on robust multi-server support, asynchronous initialization, and improved resource management. The changes enhance reliability and scalability by supporting multiple MCP servers, ensuring tools are only available after initialization, and properly disposing of resources. Additionally, the simulation environment is updated to handle tool availability more robustly during server startup.

### MCP Tools Service Improvements

* Refactored `McpToolsService` to support multiple MCP servers using separate `Client` instances per server, with a mapping from tool names to server names for accurate tool invocation. [[1]](diffhunk://#diff-bf28477c753b3dad81918488e4173a0aece74b9ca0d0239678220559c7298664L37-R50) [[2]](diffhunk://#diff-bf28477c753b3dad81918488e4173a0aece74b9ca0d0239678220559c7298664L60-R132)
* Implemented asynchronous initialization for MCP servers and tools, including retry logic, and introduced methods to ensure initialization is completed before tools are accessed or invoked. [[1]](diffhunk://#diff-bf28477c753b3dad81918488e4173a0aece74b9ca0d0239678220559c7298664L60-R132) [[2]](diffhunk://#diff-bf28477c753b3dad81918488e4173a0aece74b9ca0d0239678220559c7298664L80-R212)
* Added a static method `isMcpServersInitialized` and environment variable `MCP_SERVERS_INITIALIZED` to track initialization status across the extension and simulation environments. [[1]](diffhunk://#diff-bf28477c753b3dad81918488e4173a0aece74b9ca0d0239678220559c7298664L37-R50) [[2]](diffhunk://#diff-bf28477c753b3dad81918488e4173a0aece74b9ca0d0239678220559c7298664L60-R132)

### Resource Management

* Overrode the `dispose` method in `McpToolsService` to close all MCP client connections, clear internal maps, and reset the initialization environment variable, ensuring proper resource cleanup.

### Simulation Environment Updates

* Updated `SimulationExtHostToolsService` to wait for MCP server initialization before returning enabled tools, combining local and MCP tools in a single result set, and logging status and timeouts for improved test reliability.

### Dependency Update

* Updated the `playwright` dependency in `package.json` from version `1.54.0` to `1.54.2` for improved compatibility and bug fixes.