### PR TITLE
support structured content for mcp server

### DIFF
--- a/src/extension/tools/vscode-node/mcpToolsService.ts
+++ b/src/extension/tools/vscode-node/mcpToolsService.ts
@@ -217,8 +217,12 @@ export class McpToolsService extends BaseToolsService {
 			throw new CancellationError();
 		}
 		const parts = [];
-		for (const part of result.content as { text: string }[]) {
-			parts.push(new LanguageModelTextPart(part.text as string));
+		if (result.structuredContent) {
+			parts.push(new LanguageModelTextPart(JSON.stringify(result.structuredContent)));
+		} else if (Array.isArray(result.content)) {
+			for (const part of result.content as { text: string }[]) {
+				parts.push(new LanguageModelTextPart(part.text as string));
+			}
 		}
 		return new LanguageModelToolResult(parts);
 	}

--- a/src/extension/tools/vscode-node/mcpToolsService.ts
+++ b/src/extension/tools/vscode-node/mcpToolsService.ts
@@ -219,10 +219,9 @@ export class McpToolsService extends BaseToolsService {
 		const parts = [];
 		if (result.structuredContent) {
 			parts.push(new LanguageModelTextPart(JSON.stringify(result.structuredContent)));
-		} else if (Array.isArray(result.content)) {
-			for (const part of result.content as { text: string }[]) {
-				parts.push(new LanguageModelTextPart(part.text as string));
-			}
+		}
+		for (const part of result.content as { text: string }[]) {
+			parts.push(new LanguageModelTextPart(part.text as string));
 		}
 		return new LanguageModelToolResult(parts);
 	}


### PR DESCRIPTION
This pull request makes a minor update to the `McpToolsService` class to include structured content in the output, if available. The change ensures that any `structuredContent` from the result is serialized and added as a text part before the regular content parts.

- Output Handling:
  * [`src/extension/tools/vscode-node/mcpToolsService.ts`](diffhunk://#diff-bf28477c753b3dad81918488e4173a0aece74b9ca0d0239678220559c7298664R220-R222): Modified the result handling logic in `McpToolsService` to include `structuredContent` (if present) as a serialized JSON text part before appending the standard content parts.