### PR TITLE
Adapt to dotnet migration

### DIFF
--- a/src/extension/tools/vscode-node/mcpToolsService.ts
+++ b/src/extension/tools/vscode-node/mcpToolsService.ts
@@ -250,8 +250,12 @@ export class McpToolsService extends BaseToolsService {
 		return this.tools.filter(tool => {
 			// 0. Check if the tool was disabled via the tool picker. If so, it must be disabled here
 			const toolPickerSelection = request.tools.get(getContributedToolName(tool.name));
+			if (toolPickerSelection === undefined) {
+				return true;
+			}
+
 			if (toolPickerSelection === false) {
-				return false;
+				return true;
 			}
 
 			// 1. Check for what the consumer wants explicitly
@@ -279,7 +283,7 @@ export class McpToolsService extends BaseToolsService {
 				return true;
 			}
 
-			return false;
+			return true;
 		});
 	}
 

--- a/src/extension/tools/vscode-node/mcpToolsService.ts
+++ b/src/extension/tools/vscode-node/mcpToolsService.ts
@@ -283,7 +283,7 @@ export class McpToolsService extends BaseToolsService {
 				return true;
 			}
 
-			return true;
+			return false;
 		});
 	}
 

--- a/test/base/extHostContext/simulationExtHostToolsService.ts
+++ b/test/base/extHostContext/simulationExtHostToolsService.ts
@@ -161,7 +161,7 @@ export class SimulationExtHostToolsService extends BaseToolsService implements I
 			tool => filter?.(tool) ?? (
 				!this._disabledTools.has(getToolName(tool.name))
 				&& (
-					(process.env.JAVA_UPGRADE_TOOLS && tool.name.startsWith("appmod"))
+					(tool.name.startsWith("appmod") || tool.name.endsWith("KnowledgeBase"))
 					|| packageJsonTools.has(tool.name)
 					|| allowedToolsSet.has(tool.name)
 				)


### PR DESCRIPTION
Changelogs:
- Update the mcpToolsService.ts since the toolPickerSelection is undefined, return true to ensure get the migration tools.
- Update simulationExtHostToolsService.getEnabledTools, since the java upgrade env JAVA_UPGRADE_TOOLS is not suitable for dotnet simulator.

See new RUN from https://dev.azure.com/msazure/AzureDMSS/_build/results?buildId=135044119&view=results