### PR TITLE
Filter tool semantic_search

### DIFF
--- a/test/base/extHostContext/simulationExtHostToolsService.ts
+++ b/test/base/extHostContext/simulationExtHostToolsService.ts
@@ -162,7 +162,7 @@ export class SimulationExtHostToolsService extends BaseToolsService implements I
 				!this._disabledTools.has(getToolName(tool.name))
 				&& (
 					(process.env.JAVA_UPGRADE_TOOLS && tool.name.startsWith("appmod"))
-					|| packageJsonTools.has(tool.name)
+					|| (packageJsonTools.has(tool.name) && tool.name !== 'semantic_search')
 					|| allowedToolsSet.has(tool.name)
 				)
 			)


### PR DESCRIPTION
Cherry from https://github.com/saragluna/vscode-copilot-chat/pull/11

See new RUN https://dev.azure.com/msazure/AzureDMSS/_build/results?buildId=137084976&view=results

Fix below exception:
```
debug [ProxiedWorkspace] [ProxiedWorkspace] ERROR: %c  ERR color: #f33 [Extension Host] 🪵 .conversation [panel] - BillTrack (Run #1):
Error: Timeout computing embeddings
    at WorkspaceChunkSearchServiceImpl.computeEmbeddings (D:\a\1\vscode-copilot-chat\src\platform\workspaceChunkSearch\node\workspaceChunkSearchService.ts:781:10)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Promise.all (index 1)
    at logExecTime._telemetryService.sendMSFTTelemetryEvent.status.status (D:\a\1\vscode-copilot-chat\src\platform\workspaceChunkSearch\node\workspaceChunkSearchService.ts:750:47)
    at measureExecTime (D:\a\1\vscode-copilot-chat\src\platform\log\common\logExecTime.ts:19:18)
    at WorkspaceChunkSearchServiceImpl.rerankChunks (D:\a\1\vscode-copilot-chat\src\platform\workspaceChunkSearch\node\workspaceChunkSearchService.ts:691:26)
    at measureExecTime (D:\a\1\vscode-copilot-chat\src\platform\log\common\logExecTime.ts:19:18)
    at WorkspaceChunkSearchServiceImpl.rerankResultIfNeeded (D:\a\1\vscode-copilot-chat\src\platform\workspaceChunkSearch\node\workspaceChunkSearchService.ts:654:25)
    at measureExecTime (D:\a\1\vscode-copilot-chat\src\platform\log\common\logExecTime.ts:19:18)
    at measureExecTime (D:\a\1\vscode-copilot-chat\src\platform\log\common\logExecTime.ts:19:18)
    at measureExecTime (D:\a\1\vscode-copilot-chat\src\platform\log\common\logExecTime.ts:19:18)
    at WorkspaceChunks.prepare (D:\a\1\vscode-copilot-chat\src\extension\prompts\node\panel\workspace\workspaceContext.tsx:76:24)
    at annotateError (D:\a\1\vscode-copilot-chat\node_modules\@vscode\prompt-tsx\dist\base\promptRenderer.js:965:16)
    at D:\a\1\vscode-copilot-chat\node_modules\@vscode\prompt-tsx\dist\base\promptRenderer.js:169:31
    at async Promise.all (index 0)
    at PromptRendererForJSON._processPromptPieces (D:\a\1\vscode-copilot-chat\node_modules\@vscode\prompt-tsx\dist\base\promptRenderer.js:168:13)
    at PromptRendererForJSON._processPromptRenderPiece (D:\a\1\vscode-copilot-chat\node_modules\@vscode\prompt-tsx\dist\base\promptRenderer.js:200:9)
    at PromptRendererForJSON._processPromptPieces (D:\a\1\vscode-copilot-chat\node_modules\@vscode\prompt-tsx\dist\base\promptRenderer.js:184:42)
    at PromptRendererForJSON._processPromptRenderPiece (D:\a\1\vscode-copilot-chat\node_modules\@vscode\prompt-tsx\dist\base\promptRenderer.js:200:9)
    at PromptRendererForJSON._processPromptPieces (D:\a\1\vscode-copilot-chat\node_modules\@vscode\prompt-tsx\dist\base\promptRenderer.js:184:42)
    at PromptRendererForJSON._processPromptRenderPiece (D:\a\1\vscode-copilot-chat\node_modules\@vscode\prompt-tsx\dist\base\promptRenderer.js:200:9)
    at PromptRendererForJSON._processPromptPieces (D:\a\1\vscode-copilot-chat\node_modules\@vscode\prompt-tsx\dist\base\promptRenderer.js:184:42)
    at PromptRendererForJSON.renderElementJSON (D:\a\1\vscode-copilot-chat\node_modules\@vscode\prompt-tsx\dist\base\promptRenderer.js:210:9)
    at renderPromptElementJSON (D:\a\1\vscode-copilot-chat\src\extension\prompts\node\base\promptRenderer.ts:221:9)
    at CodebaseTool.invoke (D:\a\1\vscode-copilot-chat\src\extension\tools\node\codebaseTool.tsx:60:27
```